### PR TITLE
Add read-only mode for safe database inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ a fast key-value database written in Go.
 - Connect to an existing Badger DB
 - Get, set, and delete key-value pairs
 - List keys with optional glob pattern matching
+- Read-only mode for safe database inspection
 
 ## Installation
 
@@ -36,16 +37,42 @@ Run the CLI by providing the path to your Badger database:
 badger-cli /path/to/your/badger/db
 ```
 
+### Read-only Mode
+
+To open the database in read-only mode (useful for inspecting production databases safely):
+
+```sh
+badger-cli -readonly /path/to/your/badger/db
+# or
+badger-cli --readonly /path/to/your/badger/db
+```
+
+**Note**: The order of arguments is flexible. You can place the readonly flag before or after the database path:
+
+```sh
+badger-cli -readonly /path/to/your/badger/db
+badger-cli /path/to/your/badger/db -readonly
+```
+
+In read-only mode:
+- The prompt will show `[READONLY] >`
+- Only `get` and `list` commands are available
+- `set` and `delete` commands are disabled
+- The database is opened with read-only permissions
+- The database must already exist (will not create new databases)
+- If the database is already in use by another process, you may need to run without -readonly first to ensure proper initialization
+
 Once the CLI is running, you can use the following commands:
 
 - `get <key>`: Retrieve the value for a given key
-- `set <key> <value>`: Set a value for a given key
-- `delete <key>`: Delete a key-value pair
+- `set <key> <value>`: Set a value for a given key (not available in read-only mode)
+- `delete <key>`: Delete a key-value pair (not available in read-only mode)
 - `list [pattern]`: List all keys, optionally filtered by a glob pattern
 - `exit`: Exit the CLI
 
 ### Examples
 
+Normal mode:
 ```sh
 > set mykey myvalue
 Value set successfully
@@ -58,6 +85,19 @@ Value deleted successfully
 > list
 No matching keys found
 > exit
+```
+
+Read-only mode:
+```sh
+[READONLY] > get mykey
+myvalue
+[READONLY] > list my*
+mykey
+[READONLY] > set newkey newvalue
+Error: Cannot set values in read-only mode
+[READONLY] > delete mykey
+Error: Cannot delete values in read-only mode
+[READONLY] > exit
 ```
 
 ## Glob Pattern Matching
@@ -77,4 +117,3 @@ Examples:
 ## Acknowledgements
 
 The initial version of this CLI was developed with assistance from an AI language model. The code has since been modified and expanded.
-

--- a/README.md
+++ b/README.md
@@ -31,10 +31,20 @@ Or download the binary manually from the [latest release](https://github.com/lov
 
 ## Usage
 
-Run the CLI by providing the path to your Badger database:
-
 ```sh
-badger-cli /path/to/your/badger/db
+$ badger-cli -h
+
+Usage: badger-cli [options] <database_path>
+
+A command-line interface for a Badger key-value database.
+
+Options:
+    -r, --readonly  Open database in read-only mode
+    -h, --help      Show help
+
+Examples:
+    badger-cli /path/to/db
+    badger-cli --readonly /path/to/db
 ```
 
 ### Read-only Mode


### PR DESCRIPTION
## Description
Adds a read-only mode to the Badger CLI for safe database inspection without risk of accidental modifications.

## Changes
- Add `-readonly`/`--readonly` flag support
- Support flexible argument ordering (flag before/after db path)
- Replace flag package with direct os.Args parsing
- Update CLI prompt to show `[READONLY]` indicator
- Disable write commands (set, delete) in read-only mode
- Update autocomplete to exclude write commands
- Add comprehensive error handling and documentation
